### PR TITLE
chore: Se añade Husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+npx --no-install commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npm run prettier:check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npm run astro check
+npm run check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npm run astro check

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ["@commitlint/config-conventional"] };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "prepare": "husky",
+    "check": "astro check",
+    "format": "prettier --plugin=prettier-plugin-astro --write .",
+    "prettier:check": "prettier --check --plugin=prettier-plugin-astro ."
   },
   "dependencies": {
     "@astrojs/check": "0.9.4",
@@ -15,5 +19,11 @@
     "astro": "4.16.5",
     "tailwindcss": "3.4.14",
     "typescript": "5.6.3"
+  },
+  "devDependencies": {
+    "@commitlint/config-conventional": "^19.5.0",
+    "husky": "^9.1.6",
+    "prettier": "^3.3.3",
+    "prettier-plugin-astro": "^0.14.1"
   }
 }


### PR DESCRIPTION
# Se añade Husky

Se busca implementar [Husky ](https://typicode.github.io/husky/get-started.html) para tener un estandar al momento de implementar cambios

En ejemplo la siguiente imagen es al momento de intentar hacer push
![image](https://github.com/user-attachments/assets/0b262da2-a012-432d-be81-ef1b18fea84e)

En ejemplo la siguiente imagen es al momento de hacer commit
![image](https://github.com/user-attachments/assets/228d1d01-cb12-4d0c-892e-a05ea10585b9)


NOTA: Estos cambios no implementan el cambio correspondiente en formateo y/o practicas se subieron con la flag --no-verify