### PR TITLE
feat: Update HeroSearch dropdown styling

### DIFF
--- a/src/components/HeroSearch.astro
+++ b/src/components/HeroSearch.astro
@@ -36,7 +36,7 @@ const studies = await getStudies()
     <form>
       <div>
         <select
-          class="w-full py-4 border-b border-gray-300 text-gray-600 bg-transparent cursor-pointer"
+          class="w-full py-4 border-b border-gray-300 text-gray-400 bg-transparent cursor-pointer"
         >
           {
             studies.map(({ id, value, key }) => {
@@ -44,7 +44,7 @@ const studies = await getStudies()
               const literal = isDefault ? "Nivel de estudios" : value
 
               return (
-                <option value={key} disabled={isDefault} selected={isDefault}>
+                <option class={isDefault ? '': 'text-gray-600'} value={key} disabled={isDefault} selected={isDefault}>
                   {literal}
                 </option>
               )


### PR DESCRIPTION
Se actualizó el color del texto por defecto en el dropdown, sin afectar el color de los elementos que están dentro.

Antes:
![Before](https://github.com/user-attachments/assets/cb3c7db6-a36e-4c39-acfc-98fd9844db70)

Despues: 
![After](https://github.com/user-attachments/assets/fa24b5f6-e066-4b90-84e4-8bf85e1654e1)
