### PR TITLE
Cambio del texto del h1 según la resolución de la pantalla

### DIFF
--- a/src/components/HeroSearch.astro
+++ b/src/components/HeroSearch.astro
@@ -28,9 +28,14 @@ const sortedStudies = studies.sort((a, b) => a.order - b.order)
 
 <SectionContainer class="bg-hero-pattern rounded-3xl px-4 py-6">
   <h1
-    class="text-black/80 font-semibold tracking-[0.35px] text-2xl text-center pb-4 sm:text-4xl lg:pb-8"
+    class="text-black/80 font-semibold tracking-[0.35px] text-2xl text-center pb-4 sm:text-4xl lg:hidden"
   >
     Tu carrera empieza aquí
+  </h1>
+  <h1
+    class="hidden text-black/80 font-semibold tracking-[0.35px] text-2xl text-center pb-4 sm:text-4xl lg:pb-8 lg:block"
+  >
+    Conecta tus estudios con el empleo ideal
   </h1>
 
   <search class="bg-white rounded-3xl p-4 lg:mx-10">


### PR DESCRIPTION
En el diseño, el título de la Landing Page cambia según el tamaño de la pantalla. He ajustado el código para que en móviles se muestre 'Tu carrera empieza aquí' y en tabletas/escritorio, 'Conecta tus estudios con el empleo ideal', tal y como está en el diseño.

![Captura desde 2024-10-20 16-15-42](https://github.com/user-attachments/assets/604f645e-2cf9-4f87-934d-9c0eb49752fd)
![Captura desde 2024-10-20 16-16-05](https://github.com/user-attachments/assets/ff5ee9ec-6b31-4c29-a927-41acb65e59c8)
