### PR TITLE
Estilo del h2 y ancho del bento ajustado al diseño

### DIFF
--- a/src/components/BentoInfo.astro
+++ b/src/components/BentoInfo.astro
@@ -26,8 +26,8 @@ const ARTICLES = [
 ---
 
 <SectionContainer>
-  <h2 class="text-ij-black text-2xl pb-6">Prepárate para ganar</h2>
-  <div class="grid grid-cols-1 md:grid-cols-3 md:grid-rows-2 gap-4 md:p-2">
+  <h2 class="text-ij-black text-2xl md:text-3xl font-semibold pb-5">Prepárate para ganar</h2>
+  <div class="grid grid-cols-1 md:grid-cols-3 md:grid-rows-2 gap-4">
     {
       ARTICLES.map(({ class: className, title, contentId }) => (
         <button


### PR DESCRIPTION
Se han modificado los estilos del h2 del bento-info para que sea igual al de todas las secciones. Además, se ha ajustado el ancho del bento al ancho de toda la página.

Antes:
![Captura desde 2024-10-20 16-44-06](https://github.com/user-attachments/assets/d67d645e-4964-43cf-ab85-8e290ca113ec)

Después:
![Captura desde 2024-10-20 16-44-47](https://github.com/user-attachments/assets/b934e129-e379-401d-8ed1-ff562932c645)
