### PR TITLE
styles(CoolJobs): add space between CoolJobCard and horizontal scroll bar

### DIFF
--- a/src/components/CoolJobs.astro
+++ b/src/components/CoolJobs.astro
@@ -63,7 +63,7 @@ const coolJobs: CoolJobs[] = [
     </h2>
 
     <div
-      class="flex items-center gap-6 overflow-x-auto -mx-4 px-4 lg:p-0 lg:m-0 lg:grid lg:grid-cols-4 lg:w-[1200px] lg:z-10"
+      class="flex items-center gap-6 overflow-x-auto -mx-4 px-4 lg:p-0 lg:m-0 lg:grid lg:grid-cols-4 lg:w-[1200px] lg:z-10 pb-6"
     >
       {
         coolJobs.map(({ image, title, brand, section_id }) => (


### PR DESCRIPTION
Add a space between CoolJobCard and the horizontal scroll bar

Before:
![image](https://github.com/user-attachments/assets/1c3e67d8-9797-4a63-a413-be6c3d951d44)

After:
![image](https://github.com/user-attachments/assets/5ffbb1b2-e480-4a03-9aa6-f8f836b7d012)
