### PR TITLE
style(CoolJobBrand): Improve clickable area of anchor element for better user experience

### DIFF
--- a/src/components/CoolJobBrand.astro
+++ b/src/components/CoolJobBrand.astro
@@ -1,20 +1,22 @@
-<a
-  href="https://cooljobs.infojobs.net/"
-  target="_blank"
-  rel="noopener noreferrer"  
-  class="flex justify-center items-center"
+<div
+  class:list={[
+    "group bg-[#fe52308f] w-[275px] h-[130px] rounded-2xl gap-4 lg:flex-col lg:items-start lg:justify-center m-auto",
+    Astro.props.class,
+  ]}
 >
-  <div
-    class:list={[
-      "group bg-[#fe52308f] w-[275px] h-[130px] rounded-2xl p-6 gap-4 lg:flex-col lg:items-start lg:justify-center ",
-      Astro.props.class,
-    ]}
+  <a
+    href="https://cooljobs.infojobs.net/"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="flex flex-col justify-center items-center w-full h-full p-6"
   >
     <img
       src="/img/cool-jobs/cool-jobs.webp"
       alt="Logo Cool Jobs"
       class="px-4 lg:px-0 group-hover:scale-105 transition-transform"
     />
-    <p class="text-white text-sm p-4 tracking-[0.1px] text-center md:p-0 ">{"Ver todos >"}</p>
-  </div>
-</a>
+    <p class="text-white text-sm p-4 tracking-[0.1px] text-center md:p-0">
+      {"Ver todos >"}
+    </p>
+  </a>
+</div>


### PR DESCRIPTION
Removed the extra clickable area of the anchor element.  Only the intended area is clickable, improving user experience.
Before:
![InfoJobs - ¡Encuentra tu primer empleo! — Mozilla Firefox 2024-10-21 17-01-32](https://github.com/user-attachments/assets/ca12b48a-32c3-444d-abbc-14f688b18189)

After:
![InfoJobs - ¡Encuentra tu primer empleo! — Mozilla Firefox 2024-10-21 17-12-34](https://github.com/user-attachments/assets/93dbe74a-0393-421e-be53-aeddb33cb715)
