### PR TITLE
chore(hover-underline): Arreglar subrayado para todos los elementos y agregando animación

### DIFF
--- a/src/components/AdevintaInfo.astro
+++ b/src/components/AdevintaInfo.astro
@@ -28,13 +28,13 @@ const LINKS = [
 ];
 ---
 
-<div class="flex flex-col items-center px-10">
+<div class="flex flex-col items-center px-10 gap-10">
   <ul
-    class="hidden md:inline-flex gap-x-16 gap-y-4 flex-wrap justify-between text-sm w-full pb-10 underline-offset-[3px]"
+    class="hidden md:inline-flex gap-x-16 gap-y-4 flex-wrap justify-between text-sm w-full underline-offset-[3px]"
   >
     <li>
       <span>InfoJobs es parte de </span>
-      <a class="hover:underline" href={ADEVINTA_LINK} target="_blank"
+      <a class="relative after:absolute after:bottom-0 after:left-0 after:content-[''] after:h-px after:bg-black after:w-0 md:hover:after:w-full after:transition-[width] after:duration-300" href={ADEVINTA_LINK} target="_blank"
         >Adevinta</a
       >
     </li>
@@ -43,7 +43,7 @@ const LINKS = [
       LINKS.map(({ label, href }) => (
         <li class="flex-grow text-center">
           <a
-            class="hover:underline"
+            class="relative after:absolute after:bottom-0 after:left-0 after:content-[''] after:h-px after:bg-black after:w-0 md:hover:after:w-full after:transition-[width] after:duration-300 box-border"
             href={href}
             target="_blank"
             aria-label={`Visita ${label}`}

--- a/src/components/LinksColumns.astro
+++ b/src/components/LinksColumns.astro
@@ -113,11 +113,11 @@ const linksInfo = [
                   <li
                     class={
                       label !== "Ayuda" && label !== "Condiciones legales"
-                        ? "hidden md:block hover:underline"
-                        : "md:hover:underline"
+                        ? "hidden md:block"
+                        : ""
                     }
                   >
-                    <a href={href} class="text-[14px] leading-6 ">
+                    <a href={href} class="text-[14px] inline-block leading-6 relative after:absolute after:bottom-[2.5px] after:left-0 after:content-[''] after:h-px after:bg-black after:w-full md:after:w-0 md:hover:after:w-full after:transition-[width] after:duration-300">
                       {label}
                     </a>
                   </li>

--- a/src/components/LinksColumns.astro
+++ b/src/components/LinksColumns.astro
@@ -107,15 +107,15 @@ const linksInfo = [
             <h2 class="text-black font-semibold text-[18px]  hidden md:block">
               {title}
             </h2>
-            <ul class="flex flex-row  md:flex-col underline md:no-underline gap-4 md:gap-0">
+            <ul class="flex flex-row md:mt-2 md:flex-col underline md:no-underline md:gap-2 gap-6">
               {links.map(({ label, href }) => {
                 return (
                   <li
-                    class={`mb-2 ${
+                    class={
                       label !== "Ayuda" && label !== "Condiciones legales"
                         ? "hidden md:block hover:underline"
-                        : ""
-                    }`}
+                        : "md:hover:underline"
+                    }
                   >
                     <a href={href} class="text-[14px] leading-6 ">
                       {label}


### PR DESCRIPTION
- Los elementos `Ayuda` y `Condiciones legales` en el `footer` no tenían subrayado a partir de `768px`, esto difería con los demás enlaces.
- Se utilizaba `margin` para la separación de elementos. Ahora se utiliza `gap`.
- Se creó una transición con el pseudo elemento `after` que simula el subrayado de los enlaces.
- El diseño en móvil no se ve afectado

**Antes**:
![before-hover-footer-link](https://github.com/user-attachments/assets/0f1f0c45-3f39-4ea2-95cb-7a5ad94b92db)
![imagen](https://github.com/user-attachments/assets/514db37a-a11b-4e9a-8cc7-283e1a3617dd)
**Después**:
![after-hover-footer-link](https://github.com/user-attachments/assets/8697341c-98c5-41b4-9de3-a1acb5006685)
![imagen](https://github.com/user-attachments/assets/b3a204da-b6de-44ea-9bf4-91a7a252cb7c)


