### PR TITLE
fix(BentoInfo.astro): disable page scroll when modal is active

### DIFF
--- a/src/components/BentoInfo.astro
+++ b/src/components/BentoInfo.astro
@@ -138,6 +138,7 @@ const ARTICLES = [
     const $modal = document.getElementById("infographic-modal");
     const $modalBody = document.getElementById("infographic-modal-body");
     const $btnModal = document.getElementById("btn-modal");
+    const $body = document.body
 
     //buttons bento
     const $buttons = document.querySelectorAll("button[data-content-id]");
@@ -151,6 +152,8 @@ const ARTICLES = [
         $modalBody.replaceChildren(content.cloneNode(true));
 
         $modalBody.firstElementChild?.classList.replace("hidden", "flex");
+
+        $body.style.overflow = 'hidden';
       }
     };
 
@@ -164,6 +167,8 @@ const ARTICLES = [
       if (currentContent) {
         $modalBody?.removeChild(currentContent);
       }
+
+      $body.style.overflow = "";
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
Cuando se hace scroll y se llega al tope ya sea arriba o abajo y se sigue haciendo scroll la pagina principal se desplaza.
Se ha modificado para que cuando la modal esté abierta el scroll en la página principal se deshabilite.