### PR TITLE
style(CoolJobs):Apply margins on mobile devices to maintain design harmony

### DIFF
--- a/src/components/CoolJobs.astro
+++ b/src/components/CoolJobs.astro
@@ -52,7 +52,7 @@ const coolJobs: CoolJobs[] = [
 
 <section class="mx-auto w-full lg:max-w-7xl lg:px-4 ">
   <article
-    class="p-4 pb-6 flex flex-col gap-6 bg-gradient-to-r from-[#FFDEDA] to-[#FCEDEB] lg:py-15 lg:px-10 lg:rounded-2xl lg:items-center lg:overflow-hidden lg:relative"
+    class="p-4 pb-6 flex flex-col gap-6 bg-gradient-to-r from-[#FFDEDA] to-[#FCEDEB] ml-4 mr-4 rounded-2xl lg:py-15 lg:px-10 lg:items-center lg:overflow-hidden lg:relative lg:m-0"
   >
     <CoolJobBackground />
 


### PR DESCRIPTION
Applied margins on mobile devices to ensure a consistent and harmonious design in "Los trabajos más cool".
Before:
![image](https://github.com/user-attachments/assets/b634ac3d-5b35-4562-93c3-40170f7706e9)

After:
![image](https://github.com/user-attachments/assets/01e6ac54-71a9-4d5f-bbd1-1a1a4f0964c5)