### PR TITLE
fix: add-dynamic-id-to-tiktok-button

### DIFF
--- a/src/components/TiktokVideo.astro
+++ b/src/components/TiktokVideo.astro
@@ -21,7 +21,7 @@ const { videoId, thumbnailUrl, title } = Astro.props
 >
   <div
     class="p-4 pl-[18px] bg-white rounded-full absolute bottom-6 right-6 hover:scale-110 transition-transform"
-    id="play-button"
+    id=`Id${videoId}`
     title={title}
   >
     <Icon name="play" class="text-primary" />
@@ -45,7 +45,7 @@ const { videoId, thumbnailUrl, title } = Astro.props
     activateVideo() {
       this.style.backgroundImage = "unset"
 
-      this.querySelector("#play-button")?.remove()
+      this.querySelector(`Id${this.videoId}`)?.remove()
 
       const iframeEl = this.createIframe()
       this.append(iframeEl)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ee397b6-06fe-43a9-aba5-07109d82c0b0)

Para evitar utilizar repetidamente los ids en los botones de tiktok, se los paso de manera dinámica.

![image](https://github.com/user-attachments/assets/55e58d28-8260-4cff-9c59-3dd1aa88e1a0)

![image](https://github.com/user-attachments/assets/46c1acc9-0381-4c7e-b4e4-d91db888ad82)
