### PR TITLE
fix(TiktokVideo): Corregir querySelector en activateVideo

### DIFF
--- a/src/components/TiktokVideo.astro
+++ b/src/components/TiktokVideo.astro
@@ -45,7 +45,7 @@ const { videoId, thumbnailUrl, title } = Astro.props
     activateVideo() {
       this.style.backgroundImage = "unset"
 
-      this.querySelector(`Id${this.videoId}`)?.remove()
+      this.querySelector(`#Id${this.videoId}`)?.remove()
 
       const iframeEl = this.createIframe()
       this.append(iframeEl)


### PR DESCRIPTION
## Descripción
En el componente TiktoVideo, en la función activateVideo, se utiliza el método querySelector para seleccionar el contenedor del botón de reproducción. Sin embargo, el selector pasado como parámetro es incorrecto porque no incluye el símbolo `#` para el id del elemento. Esto provoca que el botón de reproducción no desaparezca y, al hacer clic nuevamente, se genere un segundo video debajo del primero, lo que rompe la interfaz de usuario.

## Comportamiento actual
![before](https://github.com/user-attachments/assets/8dbd8e3f-b314-49cb-9c63-18e65d361146)

## Comportamiento corregido
![after](https://github.com/user-attachments/assets/ab74dae4-da93-48aa-9740-13d67958a394)
