### PR TITLE
feat(LinksColumns): Add target blank links footer

### DIFF
--- a/src/components/LinksColumns.astro
+++ b/src/components/LinksColumns.astro
@@ -122,7 +122,7 @@ const linksInfo = [
                     showOnMobile ? "" : "hidden md:block",
                   ]}
                 >
-                  <a href={href} class="text-[14px] leading-6 ">
+                  <a href={href} class="text-[14px] leading-6" target="_blank" rel="noopener noreferrer" aria-label={label}>
                     {label}
                   </a>
                 </li>


### PR DESCRIPTION
## Motivación

La razón más común para utilizar `target="_blank"` es que los enlaces externos se abran en una pestaña aparte. Esto permite al usuario hacer clic en una referencia y volver a ella más tarde sin salir de la página actual. Mantiene a los visitantes en su sitio durante más tiempo y mejora la mayoría de sus métricas: tasa de rebote, conversión, páginas visitadas.

![image](https://github.com/user-attachments/assets/2ade0cc0-8bba-406a-a9e8-3027bd90a3a4)

## Comportamiento corregido

Añadido para todos los enlaces del footer, esta funcionalidad más `rel="noopener noreferrer"` y `aria-label`.

- `rel noopener`: Aumenta la seguridad de su propio sitio web, sino que también protege a los visitantes de su propio sitio web de los daños causados por ataques de hackers a través de `[window.open.location]` y URL incorrectas.
- `aria-label`: El atributo [aria-label](https://www.w3.org/TR/wai-aria/#aria-label) se utiliza para definir una cadena que etiqueta el elemento actual.