### PR TITLE
fix: blank spaces in readme steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,25 +156,25 @@ Este proyecto es una landing page para InfoJobs, diseñada para proporcionar una
 Clona el proyecto
 
 ```bash
-  git clone https://github.com/midudev/landing-infojobs.git
+git clone https://github.com/midudev/landing-infojobs.git
 ```
 
 Dirigete al directorio del proyecto
 
 ```bash
-  cd landing-infojobs
+cd landing-infojobs
 ```
 
 Instala las dependencias
 
 ```bash
-  npm install
+npm install
 ```
 
 Inicia el servidor
 
 ```bash
-  npm run start
+npm run start
 ```
 
 


### PR DESCRIPTION
## Motivación

En los pasos del README para poder correr localmente el proyecto, hay espacios en blanco demás en los code snippets.

![image](https://github.com/user-attachments/assets/ea0a4506-aeb2-4590-9aa9-c3380f958971)

## Comportamiento corregido

Quitados dichos espacios en blanco para evitar posibles problemas al copiar y ejecutar los comandos con espacios en blanco.