### PR TITLE
fix: shorcuts spacing in small screens

### DIFF
--- a/src/components/HeroSearch.astro
+++ b/src/components/HeroSearch.astro
@@ -95,11 +95,11 @@ const sortedStudies = studies.sort((a, b) => a.order - b.order)
 
   <footer>
     <h5 class="text-center pt-8 pb-4">Explora trabajos que se adaptan a ti</h5>
-    <div class="flex flex-wrap gap-4 justify-center">
+    <div class="max-xs:grid-cols-1 max-sm:grid max-sm:grid-cols-2 flex flex-wrap gap-4 justify-center">
       {
         SHORTCUTS.map(({ label, href }) => (
           <a
-            class="bg-white rounded-full p-4 lg:px-6 shadow-sm text-primary transition hover:scale-105 hover:text-white hover:bg-primary"
+            class="bg-white whitespace-nowrap text-center rounded-full p-4 lg:px-6 shadow-sm text-primary transition hover:scale-105 hover:text-white hover:bg-primary"
             href={href}
           >
             {label}


### PR DESCRIPTION
Hola! Estaba viendo el streaming y pensé que sería una buena idea aplicar grid en pantallas más pequeñas. No es exactamente el diseño, pero así al menos no quedan espacios extraños cuando los elementos saltan a más de una línea.

<img width="770" alt="Screenshot 2024-10-23 at 15 25 08" src="https://github.com/user-attachments/assets/3d3de204-8dae-4a91-9338-7f0202f4f93c">

<img width="509" alt="Screenshot 2024-10-23 at 15 25 17" src="https://github.com/user-attachments/assets/f1f2bb2a-55eb-4a2d-b220-092d91a116fe">

<img width="401" alt="Screenshot 2024-10-23 at 15 25 24" src="https://github.com/user-attachments/assets/1fdd7d99-1497-4542-aaa6-e847959d2890">
