### PR TITLE
fix: responsive en tarjetas oportunidades

### DIFF
--- a/src/components/OportunidadesTikTok.astro
+++ b/src/components/OportunidadesTikTok.astro
@@ -21,7 +21,7 @@ const cardsOportunidades = [
 ] as const
 ---
 
-<div class="grid grid-cols-1 md:grid-cols-2 w-auto h-auto gap-6 md:gap-[40px]">
+<div class="grid grid-cols-1 sm:grid-cols-2 w-auto h-auto gap-6 sm:gap-[40px]">
   {
     cardsOportunidades.map((card) => (
       <a
@@ -29,11 +29,11 @@ const cardsOportunidades = [
         href={card.href}
         target="_blank"
       >
-        <p class="mt-4 text-2xl sm:text-4xl md:text-2xl lg:text-2xl font-semibold text-gray-900">
+        <p class="mt-4 text-2xl font-semibold text-gray-900">
           {card.title1}
         </p>
         <p
-          class={`mt-2 text-3xl sm:text-4xl md:text-3xl lg:text-5xl font-semibold ${card.colorTitle}`}
+          class={`mt-2 text-3xl md:text-3xl lg:text-5xl font-semibold ${card.colorTitle}`}
         >
           {card.title2}
         </p>

--- a/src/components/OportunidadesTikTok.astro
+++ b/src/components/OportunidadesTikTok.astro
@@ -33,7 +33,7 @@ const cardsOportunidades = [
           {card.title1}
         </p>
         <p
-          class={`mt-2 text-3xl md:text-3xl lg:text-5xl font-semibold ${card.colorTitle}`}
+          class={`mt-2 text-3xl lg:text-5xl font-semibold ${card.colorTitle}`}
         >
           {card.title2}
         </p>


### PR DESCRIPTION
Había un momento en el que las cartas eran extremadamante grandes y he hehcho que el grid-col-1 se en vez de md un sm. Arreglando tambien los tamaños de letras muy grandes

Antes:
![image](https://github.com/user-attachments/assets/82233bf7-d9e9-4248-8cfe-cae58f5b7232)

Después:
![image](https://github.com/user-attachments/assets/d6448e03-4367-4073-aab3-e66343ba15ca)

Mi primera PR 😊