### PR TITLE
style(TiktokVideo.astro): add hover animation

### DIFF
--- a/src/components/TiktokVideo.astro
+++ b/src/components/TiktokVideo.astro
@@ -11,7 +11,7 @@ const { videoId, thumbnailUrl, title } = Astro.props
 ---
 
 <tiktok-video
-  class="rounded-2xl bg-cover h-[570px] w-80 snap-center bg-black relative shrink-0 cursor-pointer"
+  class="rounded-2xl bg-cover h-[570px] w-80 snap-center bg-black relative shrink-0 cursor-pointer hover:scale-95 transition-transform"
   videoid={videoId}
   thumbnailurl={thumbnailUrl}
   data-title={title}


### PR DESCRIPTION
Se añadió una animación de escala en los videos al hacer hover, reduciendo el tamaño del video.

Antes:
![image](https://github.com/user-attachments/assets/059804b8-21db-4d33-864f-45a45904140f)


Después:
![image](https://github.com/user-attachments/assets/bbdee1c5-8e57-4e9e-b8b0-6c52b925e872)

