### PR TITLE
fix: update padding for article layout in footer on mobile

### DIFF
--- a/src/components/FollowUs.astro
+++ b/src/components/FollowUs.astro
@@ -56,7 +56,7 @@ const hoverStoreApps = "md:transition-[filter] md:hover:saturate-150";
   </article>
 
   <article
-    class="w-full flex items-center justify-center gap-4 pb-4 flex-wrap md:flex-nowrap md:pb-0 md:gap-2 md:justify-end"
+    class="w-full flex items-center justify-center gap-4 py-4 flex-wrap md:flex-nowrap md:p-0 md:gap-2 md:justify-end"
   >
     <FollowUsLink
       href="https://infojobs.go.link/?adj_t=1b8zxouv_1bnixj2z"


### PR DESCRIPTION
The padding in the downloads article was updated to improve its design on mobile devices.

The changes include modifying the Tailwind CSS classes from `pb-4` to `py-4` and from `md:pb-0` to `md:p-0`.

This ensures that the content in the footer has proper spacing, which improves alignment and consequently provides a more visually pleasing experience on small screens.

**before:**
![before](https://github.com/user-attachments/assets/2f94952e-b142-451c-a2e8-4f693ceceba2)

**after:**
![after](https://github.com/user-attachments/assets/76761621-7473-4663-b44e-3954b370baf3)
