### PR TITLE
fix: adjust border radius of Tiktok video component

### DIFF
--- a/src/components/TiktokVideo.astro
+++ b/src/components/TiktokVideo.astro
@@ -11,7 +11,7 @@ const { videoId, thumbnailUrl, title } = Astro.props
 ---
 
 <tiktok-video
-  class="rounded-[32px] bg-cover h-[570px] w-80 snap-center bg-black relative shrink-0 cursor-pointer"
+  class="rounded-[16px] bg-cover h-[570px] w-80 snap-center bg-black relative shrink-0 cursor-pointer"
   videoid={videoId}
   thumbnailurl={thumbnailUrl}
   data-title={title}


### PR DESCRIPTION
Modifiqué el border-radius en el componente TikTok para que coincida con el borde del video cuando está en reproducción.

Antes:
<img width="1019" alt="Screenshot 2024-10-24 at 8 36 44 PM" src="https://github.com/user-attachments/assets/7dca0573-84ad-48cf-be9d-6473d15362cf">

Despues:
<img width="1019" alt="Screenshot 2024-10-24 at 8 37 06 PM" src="https://github.com/user-attachments/assets/e1c3a9b6-4617-43f1-86e3-52b9556a2720">
