### PR TITLE
fix gap-x on AdevintaInfo.astro

### DIFF
--- a/src/components/AdevintaInfo.astro
+++ b/src/components/AdevintaInfo.astro
@@ -6,7 +6,7 @@ const LINKS = [
     href: "https://www.fotocasa.es/es",
   },
   {
-    label: "habitaclia",
+    label: "Habitaclia",
     href: "https://www.habitaclia.com/",
   },
   {
@@ -30,7 +30,7 @@ const LINKS = [
 
 <div class="flex flex-col items-center px-10">
   <ul
-    class="hidden md:inline-flex gap-x-16 gap-y-4 flex-wrap justify-between text-sm w-full pb-10 underline-offset-[3px]"
+    class="hidden md:inline-flex gap-x-2 gap-y-4 flex-wrap justify-between text-sm w-full pb-10 underline-offset-[3px]"
   >
     <li>
       <span>InfoJobs es parte de </span>


### PR DESCRIPTION
Cambié una propiedad de tailwindcss que rompía los estilos del footer en la información de Adevinta, el cambio pasó de gap-x-16 a gap-x-2 para que no se rompan los estilos debido a la cantidad del espacio entre links.

Before
<img width="823" alt="Captura de pantalla 2024-10-25 a las 16 06 52" src="https://github.com/user-attachments/assets/abfdca24-dc10-4f38-9dfb-931628e1b0b2">

After
<img width="817" alt="Captura de pantalla 2024-10-25 a las 16 22 53" src="https://github.com/user-attachments/assets/3eba00c6-bb95-4025-aa18-37d4806ac3cc">
