### PR TITLE
Hero search shortcuts

### DIFF
--- a/src/components/AdevintaInfo.astro
+++ b/src/components/AdevintaInfo.astro
@@ -6,7 +6,7 @@ const LINKS = [
     href: "https://www.fotocasa.es/es",
   },
   {
-    label: "habitaclia",
+    label: "Habitaclia",
     href: "https://www.habitaclia.com/",
   },
   {
@@ -30,7 +30,7 @@ const LINKS = [
 
 <div class="flex flex-col items-center px-10">
   <ul
-    class="hidden md:inline-flex gap-x-16 gap-y-4 flex-wrap justify-between text-sm w-full pb-10 underline-offset-[3px]"
+    class="hidden md:inline-flex gap-x-2 gap-y-4 flex-wrap justify-between text-sm w-full pb-10 underline-offset-[3px]"
   >
     <li>
       <span>InfoJobs es parte de </span>

--- a/src/components/HeroSearch.astro
+++ b/src/components/HeroSearch.astro
@@ -81,7 +81,7 @@ const sortedStudies = studies.sort((a, b) => a.order - b.order)
           <input
             name="geolocation"
             placeholder="Provincia o población"
-            class="w-full py-4 text-gray-600 focus:outline-none"
+            class="w-full py-4 border-b border-gray-300 text-gray-600 focus:outline-none lg:border-none"
           />
         </div>
 


### PR DESCRIPTION
Agregué una lía por debajo del campo de búsqueda de la población o la provincia para una mejor legibilidad.

Before
<img width="687" alt="Captura de pantalla 2024-10-25 a las 17 56 22" src="https://github.com/user-attachments/assets/2a841c43-bca9-4e11-9dc3-9c70ef0a721b">

After
<img width="691" alt="Captura de pantalla 2024-10-25 a las 17 56 06" src="https://github.com/user-attachments/assets/029ca466-141a-46d3-99a8-b2167c414f7e">
