### PR TITLE
style(InfographicModal) section padding fixed

### DIFF
--- a/src/components/InfographicModal.astro
+++ b/src/components/InfographicModal.astro
@@ -4,7 +4,7 @@ import CloseIcon from "@icons/CloseIcon.astro";
 
 <section
   id="infographic-modal"
-  class="transition-all fixed inset-0 bg-white p-2 z-[999] opacity-0 invisible"
+  class="transition-all fixed inset-0 bg-white py-2 z-[999] opacity-0 invisible"
 >
   <header class="w-full h-[40px] flex items-center justify-end px-4 lg:px-8">
     <button


### PR DESCRIPTION
Improved padding for the InfographicModal.astro section. Removed horizontal padding that was causing unnecessary whitespace near the scrollbar, reducing visual noise.

Before:

![image](https://github.com/user-attachments/assets/db2cfe00-1726-4b51-bcbc-00c4b390b1b5)
![image](https://github.com/user-attachments/assets/b11d68cf-1c5b-44e3-b413-7a25d1672a23)

After:
![image](https://github.com/user-attachments/assets/810a95ed-b6d8-4164-84bb-b70a7cf6e6c8)
![image](https://github.com/user-attachments/assets/ce2333fc-7980-4bb2-869d-1d8d3ac4dbed)