### PR TITLE
ADDED hover effect on CoolBrandJobs text ver todos

### DIFF
--- a/src/components/CoolJobBrand.astro
+++ b/src/components/CoolJobBrand.astro
@@ -16,7 +16,7 @@
       class="px-0 group-hover:scale-105 transition-transform"
     />
     <p
-      class="text-white text-sm p-0 text-center md:pl-1 md:text-start md:w-full"
+      class="text-white text-sm p-0 group-hover:scale-105 transition-transform text-center md:pl-1 md:text-start md:w-full"
     >
       {"Ver todos >"}
     </p>


### PR DESCRIPTION
Agregue el efecto hover al texto 'Ver todos >' ya que solo el logo de COOL JOBS lo tenia, os dejo una captura por aqui, lo que se ve es cuando le hice el effecto hover para alinear tanto el logo con el texto al poner el raton encima de la card.

Before
<img width="312" alt="Captura de pantalla 2024-10-27 a las 10 01 54" src="https://github.com/user-attachments/assets/4639795e-9e09-4615-bf67-b2b987a53334">

After
<img width="312" alt="Captura de pantalla 2024-10-27 a las 10 02 06" src="https://github.com/user-attachments/assets/15ef986b-2fc8-4672-b719-d6c8b473e45a">
