### PR TITLE
Refactor geolocation input styles on HeroSearch component

### DIFF
--- a/src/components/HeroSearch.astro
+++ b/src/components/HeroSearch.astro
@@ -126,7 +126,7 @@ const sortedStudies = studies.sort((a, b) => a.order - b.order)
           <input
             name="geolocation"
             placeholder="Provincia o población"
-            class="w-full py-3 lg:px-3 border-b border-gray-300 lg:border-none !text-gray-600 focus:outline-none lg:focus-visible:bg-[#E8F2F8] lg:focus-visible:outline lg:focus-visible:outline-[#167DB7] lg:focus-visible:outline-1 lg:focus-visible:outline-offset-0 lg:focus-visible:rounded-lg"
+            class="w-full py-3 lg:px-3 border-b border-gray-300 lg:border-none text-gray-600 focus:outline-none lg:focus-visible:bg-[#E8F2F8] lg:focus-visible:outline lg:focus-visible:outline-[#167DB7] lg:focus-visible:outline-1 lg:focus-visible:outline-offset-0 lg:focus-visible:rounded-lg"
           />
         </div>
         <Button

--- a/src/lib/list-provinces-ids.ts
+++ b/src/lib/list-provinces-ids.ts
@@ -55,11 +55,8 @@ const listProvincesIds = {
 }
 
 export function getProvinceId(input: HTMLInputElement): void {
-  if (!input.value) return void (input.style.color = "")
-
   const provinceId = listProvincesIds[input.value as keyof typeof listProvincesIds]
   input.setAttribute("value", provinceId !== undefined ? provinceId.toString() : "0")
-  input.style.color = provinceId ? "" : "red"
 
   if (!provinceId) input.setAttribute("value", "0")
 }


### PR DESCRIPTION
Removed the _**!text-gray-600**_ class and replaced it with _**text-gray-600**_ for improved maintainability and to avoid unnecessary overrides. Additionally, removed checks for _**empty input.value**_ and also _**delete red style color**_ on incorrect province.

*_This PR re-evaluates styles and refines code structure based on feedback from my previous PR._